### PR TITLE
Add explosion animation for spaceship collisions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -18,12 +18,7 @@ $(document).ready(() => {
   }
 
   function resetSpaceShip() {
-    spaceShip.posX = 50;
-    spaceShip.posY = spaceShip.canvas.height / 2;
-    spaceShip.angle = 0;
-    spaceShip.speed = 0;
-    spaceShip.dx = 0;
-    spaceShip.dy = 0;
+    spaceShip.reset();
   }
 
   function resetGame() {

--- a/js/planet.js
+++ b/js/planet.js
@@ -31,11 +31,6 @@ Planet.prototype.collision = function (ship) {
     ship.posX < this.posX + this.radius &&
     ship.posY < this.posY + this.radius
   ) {
-    ship.posX = 50;
-    ship.posY = ship.canvas.height / 2;
-    ship.dx = 0;
-    ship.dy = 0;
-    ship.angle = 0;
-    //this.audio.play();
+    ship.triggerExplosion(ship.posX, ship.posY);
   }
 };


### PR DESCRIPTION
## Summary
- add an explosion state and animation when the spaceship collides with planets
- trigger the explosion from planet collisions and reset the ship after the animation finishes
- reuse the spaceship reset helper when restarting or advancing the game

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e648fea928832f9aedc54abd3aa5a3