### PR TITLE
Scale planet radius based on gravity

### DIFF
--- a/js/planet.js
+++ b/js/planet.js
@@ -4,13 +4,33 @@
  * @param  {number} radius - of planet
  * @param  {number} density - of planet
  */
+const BASE_PLANET_RADIUS = 50;
+const BASE_PLANET_DENSITY = Math.pow(10, 6);
+const BASE_PLANET_MASS =
+  Math.PI * Math.pow(BASE_PLANET_RADIUS, 2) * BASE_PLANET_DENSITY;
+const BASE_GRAVITY_INFLUENCE_RADIUS = 350;
+
 function Planet({ posX, posY, radius, density }) {
   this.posX = posX;
   this.posY = posY;
+  this.originalRadius = radius;
   this.radius = radius;
-  this.area = Math.PI * Math.pow(this.radius, 2);
+  this.area = Math.PI * Math.pow(this.originalRadius, 2);
   this.density = density;
   this.mass = this.area * this.density;
+
+  const massRatio = BASE_PLANET_MASS
+    ? this.mass / BASE_PLANET_MASS
+    : 1;
+  const massFactor = Math.sqrt(Math.max(massRatio, 0));
+
+  this.radius = Math.max(this.originalRadius * massFactor, 5);
+  // Expand the planet's gravity reach using the same factor so denser
+  // planets pull from farther away.
+  this.gravityInfluenceRadius = Math.max(
+    BASE_GRAVITY_INFLUENCE_RADIUS * massFactor,
+    this.radius
+  );
   this.img = new Image();
   this.img.src = "./img/planet.png";
   //this.audio = new Audio("audio/metallic_space_impact.mp3");
@@ -19,18 +39,18 @@ function Planet({ posX, posY, radius, density }) {
 Planet.prototype.draw = function (ctx) {
   ctx.save();
   ctx.beginPath();
-  ctx.drawImage(this.img, this.posX, this.posY, 100, 100);
+  const diameter = this.radius * 2;
+  ctx.drawImage(this.img, this.posX - this.radius, this.posY - this.radius, diameter, diameter);
   ctx.closePath();
   ctx.restore();
 };
 
 Planet.prototype.collision = function (ship) {
-  if (
-    ship.posX > this.posX - this.radius &&
-    ship.posY > this.posY - this.radius &&
-    ship.posX < this.posX + this.radius &&
-    ship.posY < this.posY + this.radius
-  ) {
+  const diffX = ship.posX - this.posX;
+  const diffY = ship.posY - this.posY;
+  const distance = Math.sqrt(diffX * diffX + diffY * diffY);
+
+  if (distance <= this.radius) {
     ship.triggerExplosion(ship.posX, ship.posY);
   }
 };

--- a/js/spaceShip.js
+++ b/js/spaceShip.js
@@ -54,20 +54,25 @@ SpaceShip.prototype.collision = function (planet) {
   let distance = Math.sqrt(diffX * diffX + diffY * diffY);
   let angle = Math.atan2(diffY, diffX);
 
+  const influenceRadius =
+    planet.gravityInfluenceRadius || this.gravityInfluenceRadius;
+
   if (distance < planet.radius) {
     this.dx = 0;
     this.dy = 0;
-  } else if (distance <= this.gravityInfluenceRadius) {
-    const force = this.gravityFormula(planet, distance);
+  } else if (distance <= influenceRadius) {
+    const force = this.gravityFormula(planet, distance, influenceRadius);
     this.dx += force * Math.cos(angle);
     this.dy += force * Math.sin(angle);
   }
 };
 
-SpaceShip.prototype.gravityFormula = function (planet, distance) {
+SpaceShip.prototype.gravityFormula = function (planet, distance, influenceRadius) {
   const safeDistance = Math.max(distance, 1);
   const gravityForce = (G_CONSTANT * planet.mass) / (safeDistance * safeDistance);
-  const distanceFactor = 1 - Math.min(safeDistance / this.gravityInfluenceRadius, 1);
+  const effectiveInfluenceRadius = influenceRadius || this.gravityInfluenceRadius;
+  const distanceFactor =
+    1 - Math.min(safeDistance / effectiveInfluenceRadius, 1);
   const scaledForce = gravityForce * Math.max(distanceFactor, 0);
 
   return Math.min(this.maxGravityForce, scaledForce);


### PR DESCRIPTION
## Summary
- scale each planet's visual radius using its mass so gravity strength and size stay proportional
- draw planets centered on their coordinates and rely on circular collision detection
- allow the spaceship to use each planet's gravity reach when applying gravitational pull

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e75f5c4d88832fb0b6202a8b5cb196