### PR TITLE
Fix level progression and add new stages

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -6,6 +6,9 @@ function Game(ctx) {
   this.firstClick = true;
   this.ctx = ctx;
   this.isTrained = false;
+  this.totalLevels = TOTAL_PLAYABLE_LEVELS;
+  this.winLevel = this.totalLevels + 1;
+  this.gameOverLevel = this.totalLevels + 2;
 }
 
 Game.prototype.firstFrameDraw = function () {
@@ -47,7 +50,7 @@ Game.prototype.drawGameOver = function () {
 };
 
 Game.prototype.levelText = function () {
-  if (this.level < 6) {
+  if (this.level > 0 && this.level <= this.totalLevels) {
     this.ctx.save();
     this.ctx.beginPath();
     this.ctx.fillStyle = "#fff";
@@ -78,27 +81,24 @@ Game.prototype.winFrame = function () {
 Game.prototype.start = function (engine) {
   this.level++;
   this.firstClick = false;
-  this.setLevel(this.ctx);
+  if (!this.setLevel(this.ctx)) {
+    this.level = this.winLevel;
+    return null;
+  }
   return setInterval(engine, 1000 / 30);
 };
 
 Game.prototype.setLevel = function () {
-  const levels = [
-    { goal: { posX: 300, posY: 300 }, planets: [] },
-    level1,
-    level2,
-    level3,
-    level4(this.ctx),
-  ];
-
-  if (this.level > 4) {
+  if (this.level > this.totalLevels) {
     this.winFrame();
     return false;
   }
 
-  this.planets = levels[this.level].planets;
+  const { goal, planets } = getLevelConfiguration(this.level, this.ctx);
+  const safePlanets = Array.isArray(planets) ? planets : [];
 
-  this.goal = levels[this.level].goal;
+  this.planets = safePlanets.map((planet) => ({ ...planet }));
+  this.goal = goal ? { ...goal } : { posX: 300, posY: 300 };
 
   return true;
 };

--- a/js/levels/index.js
+++ b/js/levels/index.js
@@ -1,30 +1,249 @@
 /* eslint-disable no-unused-vars */
-const level1 = {
-  goal: { posX: 100, posY: 100 },
-  planets: [{ posX: 500, posY: 500, radius: 50, density: Math.pow(10, 6) }],
-};
+const levelDefinitions = [
+  () => ({
+    goal: { posX: 300, posY: 300 },
+    planets: [],
+  }),
+  () => ({
+    goal: { posX: 900, posY: 400 },
+    planets: [
+      {
+        posX: 550,
+        posY: 400,
+        radius: 35,
+        density: Math.pow(10, 6) * 0.9,
+      },
+    ],
+  }),
+  () => ({
+    goal: { posX: 1200, posY: 150 },
+    planets: [
+      {
+        posX: 650,
+        posY: 420,
+        radius: 55,
+        density: Math.pow(10, 6) * 1.1,
+      },
+      {
+        posX: 820,
+        posY: 220,
+        radius: 28,
+        density: Math.pow(10, 6) * 0.8,
+      },
+    ],
+  }),
+  () => ({
+    goal: { posX: 1250, posY: 600 },
+    planets: [
+      {
+        posX: 700,
+        posY: 350,
+        radius: 42,
+        density: Math.pow(10, 6) * 1.2,
+      },
+      {
+        posX: 460,
+        posY: 520,
+        radius: 30,
+        density: Math.pow(10, 6) * 0.7,
+      },
+      {
+        posX: 900,
+        posY: 220,
+        radius: 24,
+        density: Math.pow(10, 6) * 1.4,
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 250,
+      posY: ctx.canvas.height / 2,
+    },
+    planets: [
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height / 2,
+        radius: 60,
+        density: Math.pow(10, 6) * 1.5,
+      },
+      {
+        posX: ctx.canvas.width / 3,
+        posY: ctx.canvas.height / 3,
+        radius: 35,
+        density: Math.pow(10, 7) * 0.6,
+      },
+      {
+        posX: (ctx.canvas.width / 3) * 2,
+        posY: (ctx.canvas.height / 4) * 3,
+        radius: 30,
+        density: Math.pow(10, 6),
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 180,
+      posY: 140,
+    },
+    planets: [
+      {
+        posX: ctx.canvas.width / 2,
+        posY: 180,
+        radius: 38,
+        density: Math.pow(10, 6) * 1.3,
+      },
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height / 2,
+        radius: 40,
+        density: Math.pow(10, 6) * 1.2,
+      },
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height - 180,
+        radius: 38,
+        density: Math.pow(10, 6) * 1.3,
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 250,
+      posY: ctx.canvas.height - 150,
+    },
+    planets: [
+      {
+        posX: 400,
+        posY: ctx.canvas.height / 3,
+        radius: 30,
+        density: Math.pow(10, 7) * 0.6,
+      },
+      {
+        posX: 600,
+        posY: (ctx.canvas.height / 3) * 2,
+        radius: 28,
+        density: Math.pow(10, 7) * 0.8,
+      },
+      {
+        posX: 850,
+        posY: ctx.canvas.height / 2,
+        radius: 36,
+        density: Math.pow(10, 6) * 1.4,
+      },
+      {
+        posX: 1100,
+        posY: ctx.canvas.height / 2 - 120,
+        radius: 26,
+        density: Math.pow(10, 6),
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 220,
+      posY: ctx.canvas.height / 2,
+    },
+    planets: [
+      { posX: 500, posY: 160, radius: 24, density: Math.pow(10, 7) },
+      { posX: 650, posY: 360, radius: 24, density: Math.pow(10, 7) },
+      { posX: 500, posY: 560, radius: 24, density: Math.pow(10, 7) },
+      { posX: 350, posY: 360, radius: 24, density: Math.pow(10, 7) },
+      {
+        posX: 820,
+        posY: ctx.canvas.height / 2,
+        radius: 40,
+        density: Math.pow(10, 6) * 1.3,
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 200,
+      posY: 100,
+    },
+    planets: [
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height / 2,
+        radius: 70,
+        density: Math.pow(10, 6) * 1.8,
+      },
+      {
+        posX: ctx.canvas.width / 3,
+        posY: ctx.canvas.height / 4,
+        radius: 32,
+        density: Math.pow(10, 6),
+      },
+      {
+        posX: ctx.canvas.width - 450,
+        posY: ctx.canvas.height - 220,
+        radius: 28,
+        density: Math.pow(10, 6) * 1.2,
+      },
+      {
+        posX: ctx.canvas.width / 3,
+        posY: (ctx.canvas.height / 4) * 3,
+        radius: 28,
+        density: Math.pow(10, 6) * 1.1,
+      },
+    ],
+  }),
+  (ctx) => ({
+    goal: {
+      posX: ctx.canvas.width - 220,
+      posY: ctx.canvas.height - 220,
+    },
+    planets: [
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height / 2 - 120,
+        radius: 45,
+        density: Math.pow(10, 7) * 0.75,
+      },
+      {
+        posX: ctx.canvas.width / 2,
+        posY: ctx.canvas.height / 2 + 120,
+        radius: 45,
+        density: Math.pow(10, 7) * 0.75,
+      },
+      {
+        posX: ctx.canvas.width / 2 - 220,
+        posY: ctx.canvas.height / 2,
+        radius: 36,
+        density: Math.pow(10, 6) * 1.5,
+      },
+      {
+        posX: ctx.canvas.width / 2 + 220,
+        posY: ctx.canvas.height / 2,
+        radius: 36,
+        density: Math.pow(10, 6) * 1.5,
+      },
+      {
+        posX: ctx.canvas.width - 350,
+        posY: ctx.canvas.height / 2,
+        radius: 30,
+        density: Math.pow(10, 6) * 1.2,
+      },
+    ],
+  }),
+];
 
-const level2 = {
-  goal: { posX: 900, posY: 500 },
-  planets: [
-    { posX: 800, posY: 500, radius: 50, density: Math.pow(10, 6) },
-    { posX: 500, posY: 100, radius: 70, density: Math.pow(10, 6) },
-  ],
-};
+const TOTAL_PLAYABLE_LEVELS = levelDefinitions.length - 1;
 
-const level3 = {
-  goal: { posX: 1000, posY: 500 },
-  planets: [
-    { posX: 800, posY: 500, radius: 10, density: Math.pow(10, 6) },
-    { posX: 500, posY: 300, radius: 30, density: Math.pow(10, 6) },
-  ],
-};
+function getLevelConfiguration(levelIndex, ctx) {
+  const resolver = levelDefinitions[levelIndex];
 
-const level4 = (ctx) => ({
-  goal: { posX: ctx.canvas.width / 2, posY: ctx.canvas.height / 2 },
-  planets: [
-    { posX: 600, posY: 200, radius: 10, density: Math.pow(10, 8) },
-    { posX: 400, posY: 350, radius: 10, density: Math.pow(10, 8) },
-    { posX: 500, posY: 600, radius: 10, density: Math.pow(10, 8) },
-  ],
-});
+  if (!resolver) {
+    return {
+      goal: { posX: 300, posY: 300 },
+      planets: [],
+    };
+  }
+
+  if (typeof resolver === "function") {
+    return resolver(ctx);
+  }
+
+  return resolver;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ $(document).ready(() => {
   let planets = null;
   let goal = null;
   const timeLeft = 1000;
-  const gameOverCounter = 0;
+  let gameOverCounter = 0;
 
   function draw() {
     spaceShip.draw();
@@ -32,14 +32,23 @@ $(document).ready(() => {
   }
 
   function checkCollisionsWithGoal() {
-    if (goal.collision) {
-      game.setLevel();
-      game.level++;
-      game.timeLeft = timeLeft;
-      resetSpaceShip();
-      goal = new Goal(game.goal);
-      planets = game.planets.map((planet) => new Planet(planet));
+    if (!goal.collision) {
+      return;
     }
+
+    game.level++;
+    const hasNextLevel = game.setLevel();
+
+    if (!hasNextLevel) {
+      game.level = game.winLevel;
+      game.firstClick = true;
+      return;
+    }
+
+    game.timeLeft = timeLeft;
+    resetSpaceShip();
+    goal = new Goal(game.goal);
+    planets = game.planets.map((planet) => new Planet(planet));
   }
 
   function clearCanvas() {
@@ -63,19 +72,21 @@ $(document).ready(() => {
       planet.collision(spaceShip);
     });
     checkCollisionsWithGoal();
-    game.timeLeft--;
+    if (game.level <= game.totalLevels) {
+      game.timeLeft--;
+    }
 
     if (checkIfGameOver()) {
-      game.level = 7;
+      game.level = game.gameOverLevel;
       game.firstClick = true;
       gameOverCounter++;
     }
   }
 
   function engine() {
-    if (game.level === 6) {
+    if (game.level === game.winLevel) {
       game.winFrame();
-    } else if (game.level === 7) {
+    } else if (game.level === game.gameOverLevel) {
       clearInterval(interval);
       clearCanvas();
       game.drawGameOver();


### PR DESCRIPTION
## Summary
- replace the hard-coded level definitions with a richer set of nine playable stages featuring varied planet gravity and placement
- make the game engine aware of the dynamic level count so level 5 and beyond load correctly and the win/game over states trigger reliably
- adjust level advancement and timing logic so the spaceship resets properly between levels and the game no longer throws errors when time expires

## Testing
- not run (web project with no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68e774196024832f9da187028d8958ad