### PR TITLE
Add animated starfield background

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -14,6 +14,5 @@ body {
 
 
 #myCanvas {
-    background: #000 url(http://www.script-tutorials.com/demos/360/images/stars.png);
-    background-size: 100% 100%;
+    background: #000;
 }

--- a/index.html
+++ b/index.html
@@ -22,5 +22,6 @@
 <script src="./js/game.js"></script>
 <script src="./js/planet.js"></script>
 <script src="./js/spaceShip.js"></script>
+<script src="./js/starField.js"></script>
 <script src="./js/main.js"></script>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@ $(document).ready(() => {
   const context = new Context();
   const spaceShip = new SpaceShip(context.ctx, context.canvas);
   const game = new Game(context.ctx);
+  const starField = new StarField(context.ctx, context.canvas);
   let interval = null;
   let planets = null;
   let goal = null;
@@ -9,6 +10,7 @@ $(document).ready(() => {
   let gameOverCounter = 0;
 
   function draw() {
+    starField.draw();
     spaceShip.draw();
     goal.draw(spaceShip.ctx);
     game.levelText(spaceShip.ctx);

--- a/js/starField.js
+++ b/js/starField.js
@@ -1,0 +1,63 @@
+function StarField(ctx, canvas, options = {}) {
+  this.ctx = ctx;
+  this.canvas = canvas;
+  this.starCount = options.starCount || 200;
+  this.minRadius = options.minRadius || 0.5;
+  this.maxRadius = options.maxRadius || 2.2;
+  this.minAlpha = options.minAlpha || 0.2;
+  this.maxAlpha = options.maxAlpha || 0.9;
+  this.stars = this.generateStars();
+}
+
+StarField.prototype.randomBetween = function (min, max) {
+  return Math.random() * (max - min) + min;
+};
+
+StarField.prototype.generateStars = function () {
+  const stars = [];
+
+  for (let i = 0; i < this.starCount; i++) {
+    stars.push({
+      x: this.randomBetween(0, this.canvas.width),
+      y: this.randomBetween(0, this.canvas.height),
+      radius: this.randomBetween(this.minRadius, this.maxRadius),
+      alpha: this.randomBetween(this.minAlpha, this.maxAlpha),
+      twinkleSpeed: this.randomBetween(0.003, 0.01),
+      alphaDirection: Math.random() > 0.5 ? 1 : -1,
+    });
+  }
+
+  return stars;
+};
+
+StarField.prototype.twinkle = function (star) {
+  star.alpha += star.twinkleSpeed * star.alphaDirection;
+
+  if (star.alpha <= this.minAlpha) {
+    star.alpha = this.minAlpha;
+    star.alphaDirection = 1;
+  }
+
+  if (star.alpha >= this.maxAlpha) {
+    star.alpha = this.maxAlpha;
+    star.alphaDirection = -1;
+  }
+};
+
+StarField.prototype.draw = function () {
+  this.ctx.save();
+  this.ctx.fillStyle = "#000";
+  this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+
+  this.stars.forEach((star) => {
+    this.ctx.beginPath();
+    this.ctx.globalAlpha = star.alpha;
+    this.ctx.fillStyle = "#fff";
+    this.ctx.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
+    this.ctx.fill();
+    this.ctx.closePath();
+    this.twinkle(star);
+  });
+
+  this.ctx.restore();
+};


### PR DESCRIPTION
## Summary
- add animated starfield renderer to draw a twinkling open space backdrop
- integrate starfield drawing before game objects render and load new script
- simplify canvas styling to a plain black base so stars render clearly

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac938a1f0832fa4cb8e36e26d6f92)