### PR TITLE
Fix starfield visibility

### DIFF
--- a/js/spaceShip.js
+++ b/js/spaceShip.js
@@ -96,8 +96,6 @@ SpaceShip.prototype.update = function () {
 };
 
 SpaceShip.prototype.draw = function () {
-  this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-
   if (this.explosion.active) {
     this.drawExplosion();
     return;


### PR DESCRIPTION
## Summary
- stop clearing the canvas in the spaceship draw routine so the starfield background remains visible

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693acea2ea28832f8ed87d02ea947295)